### PR TITLE
Include subcomponents in single bug query result

### DIFF
--- a/client.go
+++ b/client.go
@@ -109,7 +109,7 @@ func (c *client) getBugs(url string, values *url.Values, logger *logrus.Entry) (
 // https://bugzilla.readthedocs.io/en/latest/api/core/v1/bug.html#get-bug
 func (c *client) GetBug(id int) (*Bug, error) {
 	logger := c.logger.WithFields(logrus.Fields{methodField: "GetBug", "id": id})
-	url := fmt.Sprintf("%s/rest/bug/%d", c.endpoint, id)
+	url := fmt.Sprintf("%s/rest/bug/%d?include_fields=_default,sub_components", c.endpoint, id)
 	bugs, err := c.getBugs(url, nil, logger)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The SubComponent is always an empty map since this field is not returned by default. Since we have some components that already use subcomponents, I think it might be useful to include subcomponent in the GetBug result.