### PR TITLE
test_server: work with offsets work when queried twice

### DIFF
--- a/test_server.go
+++ b/test_server.go
@@ -86,7 +86,12 @@ func (tc *testClient) handleGet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (tc *testClient) handleQuery(w http.ResponseWriter, r *http.Request) {
-	bugs := tc.getBugList()
+	offset := r.URL.Query().Get("offset")
+	bugs := BugList{}
+	if offset == "0" {
+		bugs = tc.getBugList()
+	}
+
 	b, err := json.Marshal(bugs)
 	if err != nil {
 		fmt.Printf("Unable to marshal bug data: %v\n", err)
@@ -139,7 +144,7 @@ func (tc testClient) UpdateBug(_ int, _ BugUpdate) error {
 	return nil
 }
 
-func (tc testClient) Search(query Query) ([]*Bug, error) {
+func (tc *testClient) Search(query Query) ([]*Bug, error) {
 	srv := tc.getTestServer(tc.path)
 	defer srv.Close()
 


### PR DESCRIPTION
There were 2 bugs, first when I added support for paged results I did
nothing in the test_server. So it just gave you the same bugs infinite
number of times

Second, on a query the testClient stored the bugs and bugList read from
disk. On subsequent calls it would check if the bugs in the map were set
and if so shortcircuit reading from disk. The problem is that the list
of bugs are in a struct, not a map AND the testClient.Search was pass by
value, not reference. So query was able to update the map, but not the
struct. Pass testClient by reference instead.